### PR TITLE
Merging /activities endpoints and circleci config to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,22 @@
 #
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2.1
+
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: garcialuiz/activitycollector
+    docker:
+      - image: circleci/buildpack-deps:stretch
+
 jobs:
-  build:
+  test:
     docker:
       # specify the version
       - image: cimg/go:1.14
+
+      # Test database service:
+      - image: circleci/postgres:9.6.5-alpine-ram
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -24,3 +35,69 @@ jobs:
       # specify any bash command here prefixed with `run: `
       - run: go get -v -t -d ./...
       - run: go test -v ./...
+  build:
+    executor: docker-publisher
+    working_directory: ~/go/src/github.com/garcialuis/ActivityCollector
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      - run: 
+          name: Build Docker image
+          command: docker build -t $IMAGE_NAME:latest .
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
+  publish-tagged:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load Docker image from archive
+          command: docker load -i /tmp/workspace/image.tar
+      - run: 
+          name: Publish Docker image to Docker Hub
+          command: | 
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin 
+            IMAGE_TAG=${CIRCLE_TAG/v/''}
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
+            docker push $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$IMAGE_TAG
+
+      - run: echo "Done pushing image to Docker Hub"
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test
+  test-build-tag:
+    jobs:
+      - test:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - build:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish-tagged:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2.1
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: cimg/go:1.14
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: ~/go/src/github.com/garcialuis/ActivityCollector
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/api/controllers/activity_controller.go
+++ b/api/controllers/activity_controller.go
@@ -33,6 +33,50 @@ func (server *Server) GetActivity(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	originIDParam := vars["origin_id"]
+	activityIDParam := vars["activity_id"]
+
+	if len(originIDParam) < 1 {
+		err = fmt.Errorf("Missing parameter: origin_id")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	} else if len(activityIDParam) < 1 {
+		err = fmt.Errorf("Missing parameter: activity_id")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	}
+
+	originID, err := strconv.ParseUint(originIDParam, 10, 64)
+
+	if err != nil {
+		err = fmt.Errorf("OriginID must be a number")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	}
+
+	activityID, err := strconv.ParseUint(activityIDParam, 10, 64)
+
+	if err != nil {
+		err = fmt.Errorf("ActivityID must be a number")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	}
+
+	activity, err := services.GetActivity(server.DB, originID, activityID)
+
+	if err != nil {
+		responses.ERROR(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	responses.JSON(w, http.StatusOK, activity)
+}
+
+func (server *Server) GetActivities(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	vars := mux.Vars(r)
+	originIDParam := vars["origin_id"]
 
 	if len(originIDParam) < 1 {
 		err = fmt.Errorf("Missing parameter: origin_id")
@@ -48,12 +92,60 @@ func (server *Server) GetActivity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	activity, err := services.GetActivity(server.DB, originID)
+	activities, err := services.GetActivities(server.DB, originID)
 
 	if err != nil {
 		responses.ERROR(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	responses.JSON(w, http.StatusOK, activity)
+	responses.JSON(w, http.StatusOK, activities)
+}
+
+func (server *Server) GetActivitiesInRange(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	vars := mux.Vars(r)
+	originIDParam := vars["origin_id"]
+	timeStartParam, timeEndParam := vars["starttime"], vars["endtime"]
+
+	if len(originIDParam) < 1 || len(timeStartParam) < 1 || len(timeEndParam) < 1 {
+		err = fmt.Errorf("Missing one or more parameter: origin_id, starttime, endtime")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	}
+
+	originID, err := strconv.ParseUint(originIDParam, 10, 64)
+
+	if err != nil {
+		err = fmt.Errorf("OriginID must be a number")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	}
+
+	startUnixTime, err := strconv.ParseInt(timeStartParam, 10, 64)
+
+	if err != nil {
+		err = fmt.Errorf("starttime must be a number : unixtime")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	}
+
+	endUnixTime, err := strconv.ParseInt(timeEndParam, 10, 64)
+
+	if err != nil {
+		err = fmt.Errorf("endtime must be a number : unixtime")
+		responses.ERROR(w, http.StatusBadRequest, err)
+		return
+	}
+
+	activities, err := services.GetActivitiesInRange(server.DB, originID, startUnixTime, endUnixTime)
+
+	if err != nil {
+		responses.ERROR(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	responses.JSON(w, http.StatusOK, activities)
 }

--- a/api/controllers/routes.go
+++ b/api/controllers/routes.go
@@ -7,7 +7,9 @@ func (s *Server) InitializeRoutes() {
 	// Home
 	s.Router.HandleFunc("/info", middlewares.SetMiddlewareJSON(s.Info)).Methods("GET")
 
-	s.Router.HandleFunc("/activity/{origin_id}", middlewares.SetMiddlewareJSON(s.GetActivity)).Methods("GET")
+	s.Router.HandleFunc("/activity/{origin_id}/{activity_id}", middlewares.SetMiddlewareJSON(s.GetActivity)).Methods("GET")
+	s.Router.HandleFunc("/activities/{origin_id}", middlewares.SetMiddlewareJSON(s.GetActivities)).Methods("GET")
+	s.Router.HandleFunc("/activities/{origin_id}/{starttime}/{endtime}", middlewares.SetMiddlewareJSON(s.GetActivitiesInRange)).Methods("GET")
 	s.Router.HandleFunc("/testactivity/{origin_id}", middlewares.SetMiddlewareJSON(s.GetActivitySample)).Methods("GET")
 	//TODO: s.Router.HandleFunc("/activity/{origin_id}", middlewares.SetMiddlewareJSON(s.DeleteActivity)).Methods("DELETE")
 }

--- a/api/models/activity.go
+++ b/api/models/activity.go
@@ -17,6 +17,8 @@ type Activity struct {
 	CaloriesBurned  float64 `json:"caloriesBurned" gorm:"not null"`
 }
 
+type Activities []Activity
+
 func (activity *Activity) GetActivitySample(origin uint64) (*Activity, error) {
 
 	now := time.Now()
@@ -38,10 +40,10 @@ func (activity *Activity) GetActivitySample(origin uint64) (*Activity, error) {
 	return &Activity{}, errors.New("Error: data not found")
 }
 
-// GetActivity method retrieves activity data given an originID
-func (activity *Activity) GetActivity(db *gorm.DB, origin uint64) (*Activity, error) {
+// GetActivity method retrieves activity data given an originID and activityID
+func (activity *Activity) GetActivity(db *gorm.DB, originID uint64, activityID uint64) (*Activity, error) {
 
-	err := db.Debug().Model(&Activity{}).Where("origin_id = ?", origin).Take(&activity).Error
+	err := db.Debug().Model(&Activity{}).Where("id = ? AND origin_id = ?", activityID, originID).Take(&activity).Error
 	if err != nil {
 		return &Activity{}, err
 	}
@@ -58,4 +60,25 @@ func (activity *Activity) SaveActivity(db *gorm.DB) (*Activity, error) {
 	}
 
 	return activity, err
+}
+
+func (activities *Activities) GetActivitiesInRange(db *gorm.DB, originID uint64, startUnixTime int64, endUnixTime int64) (*Activities, error) {
+
+	err := db.Debug().Model(&Activity{}).Where("origin_id = ? AND epochtime BETWEEN ? AND ?", originID, startUnixTime, endUnixTime).Find(&activities).Error
+
+	if err != nil {
+		return &Activities{}, err
+	}
+
+	return activities, nil
+}
+
+func (activities *Activities) GetActivities(db *gorm.DB, originID uint64) (*Activities, error) {
+
+	err := db.Debug().Model(&Activity{}).Where("origin_id = ?", originID).Find(&activities).Error
+	if err != nil {
+		return &Activities{}, err
+	}
+
+	return activities, nil
 }

--- a/api/models/activity_test.go
+++ b/api/models/activity_test.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSampleActivity(t *testing.T) {
+	activity := Activity{OriginID: 1}
+
+	sampleActivity, err := activity.GetActivitySample(activity.OriginID)
+
+	expectedActivity := Activity{
+		Steps:           2890,
+		CaloriesBurned:  201,
+		StandHrs:        7,
+		ExerciseMinutes: 4,
+	}
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedActivity.Steps, sampleActivity.Steps)
+	assert.Equal(t, expectedActivity.CaloriesBurned, sampleActivity.CaloriesBurned)
+	assert.Equal(t, expectedActivity.StandHrs, sampleActivity.StandHrs)
+	assert.Equal(t, expectedActivity.ExerciseMinutes, sampleActivity.ExerciseMinutes)
+}

--- a/api/models/models_init_test.go
+++ b/api/models/models_init_test.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Set up
+	fmt.Println("About to run models tests...")
+	// Run tests in package:
+	exitCode := m.Run()
+	// Actions post test
+	fmt.Println("Model tests have completed")
+	// Exit:
+	os.Exit(exitCode)
+}

--- a/api/services/activity_service.go
+++ b/api/services/activity_service.go
@@ -12,15 +12,29 @@ func GetActivitySample(originID uint64) (*models.Activity, error) {
 	return activity.GetActivitySample(originID)
 }
 
-func GetActivity(db *gorm.DB, originID uint64) (*models.Activity, error) {
+func GetActivity(db *gorm.DB, originID uint64, activityID uint64) (*models.Activity, error) {
 
 	activity := models.Activity{}
 
-	return activity.GetActivity(db, originID)
+	return activity.GetActivity(db, originID, activityID)
 }
 
 func StoreActivityRecord(db *gorm.DB, newActivity *models.Activity) (*models.Activity, error) {
 
 	// TODO: Add validation checks to make sure required fields are present
 	return newActivity.SaveActivity(db)
+}
+
+func GetActivities(db *gorm.DB, originID uint64) (*models.Activities, error) {
+
+	activities := models.Activities{}
+
+	return activities.GetActivities(db, originID)
+}
+
+func GetActivitiesInRange(db *gorm.DB, originID uint64, startUnixTime int64, endUnixTime int64) (*models.Activities, error) {
+
+	activities := models.Activities{}
+
+	return activities.GetActivitiesInRange(db, originID, startUnixTime, endUnixTime)
 }

--- a/client/activity.go
+++ b/client/activity.go
@@ -7,13 +7,12 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	client_models "github.com/garcialuis/ActivityCollector/client/models"
 )
 
 // GetActivity fetches and returns an activity with a specified originID from the database
-func (activity *ActivityCollector) GetActivity(originID uint64) (Activity client_models.Activity) {
+func (activity *ActivityCollector) GetActivity(originID uint64, activityID uint64) (Activity client_models.Activity) {
 
 	reqURL := fmt.Sprint(activity.config.hostURL, "activity/")
 	base, err := url.Parse(reqURL)
@@ -22,7 +21,7 @@ func (activity *ActivityCollector) GetActivity(originID uint64) (Activity client
 		return Activity
 	}
 
-	base.Path += strconv.FormatUint(originID, 10)
+	base.Path += fmt.Sprintf("%d/%d", originID, activityID)
 
 	resp, err := http.Get(base.String())
 	if err != nil {
@@ -44,4 +43,70 @@ func (activity *ActivityCollector) GetActivity(originID uint64) (Activity client
 	}
 
 	return Activity
+}
+
+func (activity *ActivityCollector) GetActivities(originID uint64) (Activities client_models.Activities) {
+
+	reqURL := fmt.Sprint(activity.config.hostURL, "activities/")
+	base, err := url.Parse(reqURL)
+	if err != nil {
+		log.Println("ActivityClient: Unable to parse reqURL: ", err.Error())
+		return Activities
+	}
+
+	base.Path += fmt.Sprintf("%d", originID)
+
+	resp, err := http.Get(base.String())
+	if err != nil {
+		log.Println("ActivityClient: Unable to complete request due to: ", err.Error())
+		return Activities
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	err = json.Unmarshal(body, &Activities)
+	if err != nil {
+		log.Println("ActivityClient: Unable to unmarshall Activities data retrieved: ", err.Error())
+		return Activities
+	}
+
+	return Activities
+}
+
+func (activity *ActivityCollector) GetActivitiesInRange(originID uint64, starttime uint64, endtime uint64) (Activities client_models.Activities) {
+
+	reqURL := fmt.Sprint(activity.config.hostURL, "activities/")
+	base, err := url.Parse(reqURL)
+	if err != nil {
+		log.Println("ActivityClient: Unable to parse reqURL: ", err.Error())
+		return Activities
+	}
+
+	base.Path += fmt.Sprintf("%d/%d/%d", originID, starttime, endtime)
+
+	resp, err := http.Get(base.String())
+	if err != nil {
+		log.Println("ActivityClient: Unable to complete request due to: ", err.Error())
+		return Activities
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	err = json.Unmarshal(body, &Activities)
+	if err != nil {
+		log.Println("ActivityClient: Unable to unmarshall Activities data retrieved: ", err.Error())
+		return Activities
+	}
+
+	return Activities
 }

--- a/client/models/activity.go
+++ b/client/models/activity.go
@@ -9,3 +9,5 @@ type Activity struct {
 	ExerciseMinutes uint16 `json:"exerciseMinutes" gorm:"not null"`
 	CaloriesBurned  uint16 `json:"caloriesBurned" gorm:"not null"`
 }
+
+type Activities []Activity

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/jinzhu/gorm v1.9.16
 	github.com/streadway/amqp v1.0.0
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -14,8 +16,13 @@ github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -27,3 +34,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR includes work for the folllowing:
- 3 new /activity endpoints to retrieve activity data
- We are now able to retrieve a list of activities given an originID, a specific activity record, or a list of records given an originID and a time range.
- CircleCI has now also been set up and configured to take care of running tests, building the image and publishing the image in the registry. 